### PR TITLE
Multiple root terms per ontology

### DIFF
--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -1,23 +1,21 @@
 #!/usr/bin/env python
+"""TODO: ...script docstring"""
 
 import collections
 import csv
-import nltk
-import re
-import inflection
-from nltk.tokenize import sent_tokenize, word_tokenize
-from nltk.tokenize.moses import MosesDetokenizer as detokenizer
-from nltk import pos_tag, ne_chunk
-import wikipedia
 import itertools
-from itertools import combinations
-from dateutil.parser import parse
-import sys
-from pkg_resources import resource_filename, resource_listdir
-import logging
-import collections
 import json
+import logging
 import os
+import re
+import sys
+
+import dateutil.parser
+import inflection
+import nltk
+import nltk.tokenize.moses
+import pkg_resources
+
 # TODO: We should figure out a way ontofetch can be imported remotely,
 #       as opposed to simply copying and pasting the ontofetch.py and
 #       its dependencies.
@@ -194,10 +192,11 @@ def get_component_match_withids(partial_matches, lookup_table):
 def remove_duplicate_tokens(input_string):
     refined_string=""
     new_phrase_set = []
-    string_tokens = word_tokenize(input_string.lower())
+    string_tokens = nltk.tokenize.word_tokenize(input_string.lower())
     for tkn in string_tokens:
         new_phrase_set.append(tkn)
-    refined_string = detokenizer().detokenize(new_phrase_set, return_str=True)
+    detokenizer = nltk.tokenize.moses.MosesDetokenizer()
+    refined_string = detokenizer.detokenize(new_phrase_set, return_str=True)
     refined_string=refined_string.strip()
     return refined_string
 
@@ -241,7 +240,7 @@ def is_number(inputstring):
 # 2-Method to determine  whether a string is a date or day (Used for DateOrDay Tagging)
 def is_date(inputstring):
     try:
-        parse(inputstring)
+        dateutil.parser.parse(inputstring)
         return True
     except ValueError:
         return False
@@ -271,7 +270,7 @@ def get_gram_chunks(input, num):
         * <"list">: Contains num-gram chunks as described above
     """
     # List of tokens from input
-    input_tokens = word_tokenize(input)
+    input_tokens = nltk.tokenize.word_tokenize(input)
     # input_tokens has less than 7 tokens
     if len(input_tokens) < 7:
         # Return all num-token combinations of input_tokens
@@ -308,14 +307,14 @@ def all_permutations(inputstring):
 # 9-Method to get all combinations of input string
 # TODO: This function seems unneccessary. Delete it.
 def combi(input, n):
-    output=combinations(input, n)
+    output=itertools.combinations(input, n)
     return output
 
 
 # 10-Method to get the punctuation treatment of input string - removes some predetermined punctuation and replaces it with a space
 def punctuationTreatment(inputstring, punctuationList):
     finalSample = ""
-    sampleTokens = word_tokenize(inputstring)
+    sampleTokens = nltk.tokenize.word_tokenize(inputstring)
     for token in sampleTokens:
         withoutPunctuation = ""
         number_result = is_number(token)
@@ -412,7 +411,7 @@ def get_resource_dict(file_name, lower=False):
     # Return value
     ret = {}
     # Open file_name
-    with open(resource_filename('lexmapr.resources', file_name)) as csvfile:
+    with open(pkg_resources.resource_filename('lexmapr.resources', file_name)) as csvfile:
         # Skip first line
         next(csvfile)
         # Read file_name
@@ -492,7 +491,7 @@ def get_all_resource_dicts():
         # ID corresponding to resource_term
         resource_id = ret["resource_terms_revised"][resource_term]
         # List of tokens in resource_term
-        resource_tokens = word_tokenize(resource_term.lower())
+        resource_tokens = nltk.tokenize.word_tokenize(resource_term.lower())
         # To limit performance overhead, we ignore resource_terms with
         # more than 7 tokens, as permutating too many tokens can be
         # costly. We also ignore NCBI taxon terms, as there are
@@ -773,7 +772,7 @@ def add_to_online_ontology_lookup_table(lookup_table, fetched_ontology):
             lookup_table["resource_terms_revised"][resource_label.lower()] = resource_id
 
             # List of tokens in resource_label
-            resource_tokens = word_tokenize(resource_label.lower())
+            resource_tokens = nltk.tokenize.word_tokenize(resource_label.lower())
             # Add permutations if there are less than seven tokens.
             # Permutating more tokens than this can lead to performance
             # issues.
@@ -1164,7 +1163,7 @@ def find_component_match(cleaned_sample, lookup_table, status_addendum):
             # gram_chunk concatenated into a single string
             concatenated_gram_chunk = " ".join(gram_chunk)
             # Tokenized list of concatenated_gram_chunk
-            gram_tokens = word_tokenize(concatenated_gram_chunk)
+            gram_tokens = nltk.tokenize.word_tokenize(concatenated_gram_chunk)
             # Flag indicating successful component match for i
             match_found = False
             # Permutations of concatenated_gram_chunk
@@ -1412,7 +1411,7 @@ def run(args):
 
         sample = punctuationTreatment(sample, punctuations)  # Sample gets simple punctuation treatment
         sample = re.sub(' +', ' ', sample)  # Extra innner spaces are removed
-        sampleTokens = word_tokenize(sample.lower())    #Sample is tokenized into tokenList
+        sampleTokens = nltk.tokenize.word_tokenize(sample.lower())    #Sample is tokenized into tokenList
 
         cleaned_sample = ""  # Phrase that will be used for cleaned sample
         lemma = ""
@@ -1450,10 +1449,10 @@ def run(args):
 
         #  Here we are making the tokens of cleaned sample phrase
         cleaned_sample = remove_duplicate_tokens(cleaned_sample)
-        cleaned_sample_tokens = word_tokenize(cleaned_sample.lower())
+        cleaned_sample_tokens = nltk.tokenize.word_tokenize(cleaned_sample.lower())
 
         # Part of Speech tags assigned to the tokens
-        tokens_pos = pos_tag(cleaned_sample_tokens)
+        tokens_pos = nltk.pos_tag(cleaned_sample_tokens)
 
         if args.format == "full":
             # output fields:
@@ -1505,7 +1504,7 @@ def run(args):
                 fw.write("\t" + full_term_match["matched_term"] + "\t"
                     + full_term_match["all_match_terms_with_resource_ids"])
             # Tokenize sample
-            sample_tokens = word_tokenize(sample.lower())
+            sample_tokens = nltk.tokenize.word_tokenize(sample.lower())
             # Add all tokens to covered_tokens
             [covered_tokens.append(token) for token in sample_tokens]
             # Remove all tokens from remaining_tokens
@@ -1548,7 +1547,7 @@ def run(args):
             coveredTSet = []
             remainingTSet = []
             for tknstr in partial_matches:
-                strTokens = word_tokenize(tknstr.lower())
+                strTokens = nltk.tokenize.word_tokenize(tknstr.lower())
                 for eachTkn in strTokens:
                     if ("==" in eachTkn):
                         resList = eachTkn.split("==")

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -1336,13 +1336,14 @@ def run(args):
         except FileNotFoundError:
             # Load user-specified config file into an OrderedDict
             with open(os.path.abspath(args.config)) as file:
-                config_json = json.load(file, object_pairs_hook=collections.OrderedDict)
+                config_json = json.load(file)
 
             # Create empty ontology lookup table
             ontology_lookup_table = create_online_ontology_lookup_table_skeleton()
 
             # Iterate over config_json backwards
-            for ontology_iri, root_entity_iri in reversed(config_json.items()):
+            for json_object in reversed(config_json):
+                (ontology_iri, root_entity_iri), = json_object.items()
                 # Arguments for ontofetch.py
                 if root_entity_iri == "":
                     sys.argv = ["", ontology_iri, "-o", "fetched_ontologies"]

--- a/lexmapr/tests/config/bfo.json
+++ b/lexmapr/tests/config/bfo.json
@@ -1,3 +1,3 @@
-{
-  "https://raw.githubusercontent.com/ivansg44/LexMapr/fetch_web_ontologies/lexmapr/tests/ontologies/bfo.owl": ""
-}
+[
+  {"https://raw.githubusercontent.com/ivansg44/LexMapr/fetch_web_ontologies/lexmapr/tests/ontologies/bfo.owl": ""}
+]

--- a/lexmapr/tests/config/bfo_and_pizza.json
+++ b/lexmapr/tests/config/bfo_and_pizza.json
@@ -1,4 +1,4 @@
-{
-  "https://raw.githubusercontent.com/ivansg44/LexMapr/fetch_web_ontologies/lexmapr/tests/ontologies/bfo.owl": "",
-  "https://raw.githubusercontent.com/ivansg44/LexMapr/fetch_web_ontologies/lexmapr/tests/ontologies/pizza.owl": ""
-}
+[
+  {"https://raw.githubusercontent.com/ivansg44/LexMapr/fetch_web_ontologies/lexmapr/tests/ontologies/bfo.owl": ""},
+  {"https://raw.githubusercontent.com/ivansg44/LexMapr/fetch_web_ontologies/lexmapr/tests/ontologies/pizza.owl": ""}
+]

--- a/lexmapr/tests/config/bfo_material_entity_and_pizza_spiciness.json
+++ b/lexmapr/tests/config/bfo_material_entity_and_pizza_spiciness.json
@@ -1,4 +1,4 @@
-{
-  "https://raw.githubusercontent.com/ivansg44/LexMapr/fetch_web_ontologies/lexmapr/tests/ontologies/bfo.owl": "http://purl.obolibrary.org/obo/BFO_0000040",
-  "https://raw.githubusercontent.com/ivansg44/LexMapr/fetch_web_ontologies/lexmapr/tests/ontologies/pizza.owl": "http://www.co-ode.org/ontologies/pizza/pizza.owl#Spiciness"
-}
+[
+  {"https://raw.githubusercontent.com/ivansg44/LexMapr/fetch_web_ontologies/lexmapr/tests/ontologies/bfo.owl": "http://purl.obolibrary.org/obo/BFO_0000040"},
+  {"https://raw.githubusercontent.com/ivansg44/LexMapr/fetch_web_ontologies/lexmapr/tests/ontologies/pizza.owl": "http://www.co-ode.org/ontologies/pizza/pizza.owl#Spiciness"}
+]

--- a/lexmapr/tests/config/bfo_process.json
+++ b/lexmapr/tests/config/bfo_process.json
@@ -1,3 +1,3 @@
-{
-  "https://raw.githubusercontent.com/ivansg44/LexMapr/fetch_web_ontologies/lexmapr/tests/ontologies/bfo.owl": "http://purl.obolibrary.org/obo/BFO_0000015"
-}
+[
+  {"https://raw.githubusercontent.com/ivansg44/LexMapr/fetch_web_ontologies/lexmapr/tests/ontologies/bfo.owl": "http://purl.obolibrary.org/obo/BFO_0000015"}
+]

--- a/lexmapr/tests/config/bfo_process_and_material_entity.json
+++ b/lexmapr/tests/config/bfo_process_and_material_entity.json
@@ -1,3 +1,4 @@
 [
+  {"https://raw.githubusercontent.com/ivansg44/LexMapr/fetch_web_ontologies/lexmapr/tests/ontologies/bfo.owl": "http://purl.obolibrary.org/obo/BFO_0000015"},
   {"https://raw.githubusercontent.com/ivansg44/LexMapr/fetch_web_ontologies/lexmapr/tests/ontologies/bfo.owl": "http://purl.obolibrary.org/obo/BFO_0000040"}
 ]

--- a/lexmapr/tests/config/bfo_spatial_region.json
+++ b/lexmapr/tests/config/bfo_spatial_region.json
@@ -1,3 +1,3 @@
-{
-  "https://raw.githubusercontent.com/ivansg44/LexMapr/fetch_web_ontologies/lexmapr/tests/ontologies/bfo.owl": "http://purl.obolibrary.org/obo/BFO_0000006"
-}
+[
+  {"https://raw.githubusercontent.com/ivansg44/LexMapr/fetch_web_ontologies/lexmapr/tests/ontologies/bfo.owl": "http://purl.obolibrary.org/obo/BFO_0000006"}
+]

--- a/lexmapr/tests/config/pizza.json
+++ b/lexmapr/tests/config/pizza.json
@@ -1,3 +1,3 @@
-{
-  "https://raw.githubusercontent.com/ivansg44/LexMapr/fetch_web_ontologies/lexmapr/tests/ontologies/pizza.owl": ""
-}
+[
+  {"https://raw.githubusercontent.com/ivansg44/LexMapr/fetch_web_ontologies/lexmapr/tests/ontologies/pizza.owl": ""}
+]

--- a/lexmapr/tests/config/pizza_spiciness.json
+++ b/lexmapr/tests/config/pizza_spiciness.json
@@ -1,3 +1,3 @@
-{
-  "https://raw.githubusercontent.com/ivansg44/LexMapr/fetch_web_ontologies/lexmapr/tests/ontologies/pizza.owl": "http://www.co-ode.org/ontologies/pizza/pizza.owl#Spiciness"
-}
+[
+  {"https://raw.githubusercontent.com/ivansg44/LexMapr/fetch_web_ontologies/lexmapr/tests/ontologies/pizza.owl": "http://www.co-ode.org/ontologies/pizza/pizza.owl#Spiciness"}
+]

--- a/lexmapr/tests/config/pizza_spiciness_and_pizza_two_spiciness.json
+++ b/lexmapr/tests/config/pizza_spiciness_and_pizza_two_spiciness.json
@@ -1,4 +1,4 @@
-{
-  "https://raw.githubusercontent.com/ivansg44/LexMapr/prioritize_ontology_term_selection/lexmapr/tests/ontologies/pizza.owl": "http://www.co-ode.org/ontologies/pizza/pizza.owl#Spiciness",
-  "https://raw.githubusercontent.com/ivansg44/LexMapr/prioritize_ontology_term_selection/lexmapr/tests/ontologies/pizza_two.owl": "http://www.co-ode.org/ontologies/pizza/pizza.owl#Spiciness"
-}
+[
+  {"https://raw.githubusercontent.com/ivansg44/LexMapr/prioritize_ontology_term_selection/lexmapr/tests/ontologies/pizza.owl": "http://www.co-ode.org/ontologies/pizza/pizza.owl#Spiciness"},
+  {"https://raw.githubusercontent.com/ivansg44/LexMapr/prioritize_ontology_term_selection/lexmapr/tests/ontologies/pizza_two.owl": "http://www.co-ode.org/ontologies/pizza/pizza.owl#Spiciness"}
+]

--- a/lexmapr/tests/config/pizza_two_spiciness_and_pizza_spiciness.json
+++ b/lexmapr/tests/config/pizza_two_spiciness_and_pizza_spiciness.json
@@ -1,4 +1,4 @@
-{
-  "https://raw.githubusercontent.com/ivansg44/LexMapr/prioritize_ontology_term_selection/lexmapr/tests/ontologies/pizza_two.owl": "http://www.co-ode.org/ontologies/pizza/pizza.owl#Spiciness",
-  "https://raw.githubusercontent.com/ivansg44/LexMapr/prioritize_ontology_term_selection/lexmapr/tests/ontologies/pizza.owl": "http://www.co-ode.org/ontologies/pizza/pizza.owl#Spiciness"
-}
+[
+  {"https://raw.githubusercontent.com/ivansg44/LexMapr/prioritize_ontology_term_selection/lexmapr/tests/ontologies/pizza_two.owl": "http://www.co-ode.org/ontologies/pizza/pizza.owl#Spiciness"},
+  {"https://raw.githubusercontent.com/ivansg44/LexMapr/prioritize_ontology_term_selection/lexmapr/tests/ontologies/pizza.owl": "http://www.co-ode.org/ontologies/pizza/pizza.owl#Spiciness"}
+]

--- a/lexmapr/tests/test_pipeline.py
+++ b/lexmapr/tests/test_pipeline.py
@@ -687,6 +687,24 @@ class TestOntologyMapping(unittest.TestCase):
         actual_resource_terms_id_based = ontology_lookup_table["resource_terms_ID_based"]
         self.assertDictEqual(expected_resource_terms_id_based, actual_resource_terms_id_based)
 
+    def test_ontology_table_resource_terms_ID_based_with_multiple_root_entities(self):
+        config_file_name = "bfo_process_and_material_entity"
+        test_config_file_rel_path = "tests/config/%s.json" % config_file_name
+        expected_lookup_table_name = "lookup_" + config_file_name
+        self.run_pipeline_with_args(input_file=self.small_simple_path,
+                                    config=os.path.abspath(test_config_file_rel_path))
+        ontology_lookup_table = self.get_ontology_lookup_table(expected_lookup_table_name)
+
+        expected_resource_terms_id_based = {
+            "BFO:0000024": "fiat object part",
+            "BFO:0000027": "object aggregate",
+            "BFO:0000030": "object",
+            "BFO:0000144": "process profile",
+            "BFO:0000182": "history"
+        }
+        actual_resource_terms_id_based = ontology_lookup_table["resource_terms_ID_based"]
+        self.assertDictEqual(expected_resource_terms_id_based, actual_resource_terms_id_based)
+
     def test_ontology_table_resource_terms(self):
         self.run_pipeline_with_args(input_file=self.small_simple_path,
                                     config=os.path.abspath("tests/config/bfo_material_entity.json"))


### PR DESCRIPTION
We adjust the structure of config files to be JSON arrays, where the elements are dictionaries with one key-value pair. The key is the IRI of an ontology, and the value is the IRI of an entity in said ontology. This new structure allows pipeline to fetch multiple subsets of an entity from the same ontology. i.e., there can be multiple dictionaries for the same ontology in the config file.