### PR TITLE
Remove ``mosestokenizer`` dependency

### DIFF
--- a/lexmapr/pipeline_helpers.py
+++ b/lexmapr/pipeline_helpers.py
@@ -6,8 +6,8 @@ import re
 
 from dateutil.parser import parse
 import inflection
-from mosestokenizer import MosesDetokenizer
 from nltk.tokenize import word_tokenize
+from nltk.tokenize.treebank import TreebankWordDetokenizer
 
 
 def singularize_token(tkn, lookup_table, micro_status):
@@ -79,8 +79,7 @@ def remove_duplicate_tokens(input_string):
     for token in new_phrase_list:
         if token not in refined_phrase_list:
             refined_phrase_list.append(token)
-    with MosesDetokenizer() as detokenize:
-        refined_string = detokenize(refined_phrase_list)
+    refined_string = TreebankWordDetokenizer().detokenize(refined_phrase_list)
     refined_string=refined_string.strip()
     return refined_string
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-mosestokenizer==1.1.0
 nltk==3.4.5
 wikipedia==1.4.0
 inflection==0.3.1

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(name='lexmapr',
       license='GPL-3.0',
       classifiers=classifiers,
       install_requires=[
-          'mosestokenizer==1.1.0',
           'nltk==3.4.5',
           'wikipedia==1.4.0',
           'inflection==0.3.1',


### PR DESCRIPTION
* Use ``nltk.treebank`` to detokenize instead

LexMapr Django is running into issues working with ``mosestokenizer``, so we are going to simplify things by just using a ``nltk``-native package instead.